### PR TITLE
adapt to theme without max width

### DIFF
--- a/components/splash/index.js
+++ b/components/splash/index.js
@@ -21,7 +21,7 @@ const delay = (i) => {
 
 const SplashRowDesktop = ({ components }) => {
   return (
-    <Row sx={{ height: height, my: [4, 5, 5, 5] }}>
+    <Row sx={{ height: height, my: [4, 5, 5, 6] }}>
       <Column start={[1]} width={[3]}>
         {components[0]}
       </Column>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@carbonplan/components": "^8.1.2",
         "@carbonplan/emoji": "^1.1.0",
         "@carbonplan/icons": "^1.0.0",
-        "@carbonplan/theme": "^6.0.1",
+        "@carbonplan/theme": "^7.0.0-alpha.0",
         "@stripe/stripe-js": "^1.13.2",
         "@theme-ui/color": "^0.10.0",
         "d3-array": "^2.12.1",
@@ -718,9 +718,9 @@
       }
     },
     "node_modules/@carbonplan/theme": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@carbonplan/theme/-/theme-6.0.1.tgz",
-      "integrity": "sha512-tipbyVvtBdKejuvlPSysHzHf+6Gkp3fHsB7FF46ngIIDn8yeTUOeDivcz5/Ct5weWt7FBeq57AgmdD62tw2ZDA=="
+      "version": "7.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@carbonplan/theme/-/theme-7.0.0-alpha.0.tgz",
+      "integrity": "sha512-BR0JXvM+uhoMZqJf/0B1HvunMoqY09KynDgCoU9nO/yXX2IPMzkWdoBFV+iD/c9TgQ1ZMmJ5DjeVs4WFn6dDig=="
     },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.3.0",
@@ -1591,6 +1591,7 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -4647,9 +4648,9 @@
       "requires": {}
     },
     "@carbonplan/theme": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@carbonplan/theme/-/theme-6.0.1.tgz",
-      "integrity": "sha512-tipbyVvtBdKejuvlPSysHzHf+6Gkp3fHsB7FF46ngIIDn8yeTUOeDivcz5/Ct5weWt7FBeq57AgmdD62tw2ZDA=="
+      "version": "7.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@carbonplan/theme/-/theme-7.0.0-alpha.0.tgz",
+      "integrity": "sha512-BR0JXvM+uhoMZqJf/0B1HvunMoqY09KynDgCoU9nO/yXX2IPMzkWdoBFV+iD/c9TgQ1ZMmJ5DjeVs4WFn6dDig=="
     },
     "@emotion/babel-plugin": {
       "version": "11.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@carbonplan/components": "^8.1.2",
         "@carbonplan/emoji": "^1.1.0",
         "@carbonplan/icons": "^1.0.0",
-        "@carbonplan/theme": "^7.0.0-alpha.0",
+        "@carbonplan/theme": "^7.0.0",
         "@stripe/stripe-js": "^1.13.2",
         "@theme-ui/color": "^0.10.0",
         "d3-array": "^2.12.1",
@@ -718,9 +718,9 @@
       }
     },
     "node_modules/@carbonplan/theme": {
-      "version": "7.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@carbonplan/theme/-/theme-7.0.0-alpha.0.tgz",
-      "integrity": "sha512-BR0JXvM+uhoMZqJf/0B1HvunMoqY09KynDgCoU9nO/yXX2IPMzkWdoBFV+iD/c9TgQ1ZMmJ5DjeVs4WFn6dDig=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@carbonplan/theme/-/theme-7.0.0.tgz",
+      "integrity": "sha512-wPTUBo1rHrB5xEpgZdjKDPd42D9WQH6JcmsKgONjQMAcAaRjq+TT936jH0jJEjRyu5MlKrrOq2nX7DQzCtEqtA=="
     },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.3.0",
@@ -4648,9 +4648,9 @@
       "requires": {}
     },
     "@carbonplan/theme": {
-      "version": "7.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@carbonplan/theme/-/theme-7.0.0-alpha.0.tgz",
-      "integrity": "sha512-BR0JXvM+uhoMZqJf/0B1HvunMoqY09KynDgCoU9nO/yXX2IPMzkWdoBFV+iD/c9TgQ1ZMmJ5DjeVs4WFn6dDig=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@carbonplan/theme/-/theme-7.0.0.tgz",
+      "integrity": "sha512-wPTUBo1rHrB5xEpgZdjKDPd42D9WQH6JcmsKgONjQMAcAaRjq+TT936jH0jJEjRyu5MlKrrOq2nX7DQzCtEqtA=="
     },
     "@emotion/babel-plugin": {
       "version": "11.3.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@carbonplan/components": "^8.1.2",
     "@carbonplan/emoji": "^1.1.0",
     "@carbonplan/icons": "^1.0.0",
-    "@carbonplan/theme": "^7.0.0-alpha.0",
+    "@carbonplan/theme": "^7.0.0",
     "@stripe/stripe-js": "^1.13.2",
     "@theme-ui/color": "^0.10.0",
     "d3-array": "^2.12.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@carbonplan/components": "^8.1.2",
     "@carbonplan/emoji": "^1.1.0",
     "@carbonplan/icons": "^1.0.0",
-    "@carbonplan/theme": "^6.0.1",
+    "@carbonplan/theme": "^7.0.0-alpha.0",
     "@stripe/stripe-js": "^1.13.2",
     "@theme-ui/color": "^0.10.0",
     "d3-array": "^2.12.1",

--- a/pages/index.js
+++ b/pages/index.js
@@ -65,7 +65,14 @@ const Index = () => {
               fontSize: [6, 6, 7, 8],
             }}
           >
-            Data and science for<Box as='span' sx={{display: ['none', 'none', 'none', 'initial']}}><br/></Box>climate action
+            Data and science for
+            <Box
+              as='span'
+              sx={{ display: ['none', 'none', 'none', 'initial'] }}
+            >
+              <br />
+            </Box>
+            climate action
           </Box>
           <Row columns={[6, 5, 6, 6]}>
             <Column start={[1]} width={[5, 4, 4, 4]}>

--- a/pages/index.js
+++ b/pages/index.js
@@ -65,7 +65,7 @@ const Index = () => {
               fontSize: [6, 6, 7, 8],
             }}
           >
-            Data and science for climate action
+            Data and science for<Box as='span' sx={{display: ['none', 'none', 'none', 'initial']}}><br/></Box>climate action
           </Box>
           <Row columns={[6, 5, 6, 6]}>
             <Column start={[1]} width={[5, 4, 4, 4]}>

--- a/pages/team.js
+++ b/pages/team.js
@@ -123,7 +123,6 @@ function Person({ name, role, bio, penultimate, final, color }) {
       <Column start={[1]} width={[2, 1, 1, 1]}>
         <Box
           sx={{
-            maxWidth: '100px',
             width: '100%',
             height: 'auto',
             borderRadius: '50%',


### PR DESCRIPTION
This tweaks the site in just a couple places to adapt to the new version of our theme that doesn't have a maxwidth (currently `7.0.0-alpha.0`). @jhamman @katamartin please test on actual widescreen monitors to make sure it looks ok! I've only looked at it in responsive emulation mode.

Once we've confirmed this and the related changes across our other sites, we can publish  `7.0.0` of the theme, update this PR to point to it, and merge.