### PR TITLE
use new link for files

### DIFF
--- a/pages/funding.js
+++ b/pages/funding.js
@@ -36,11 +36,11 @@ const Funding = () => {
               credits from Amazon Web Services and Microsoft Azure. Funding for
               additional, ongoing projects will be listed in the future. Read
               more in our{' '}
-              <Link href='https://carbonplan-assets.s3.amazonaws.com/docs/CarbonPlan-Annual-Report-2020.pdf'>
+              <Link href='https://files.carbonplan.org/CarbonPlan-Annual-Report-2020.pdf'>
                 2020 Annual Report
               </Link>{' '}
               or our{' '}
-              <Link href='https://carbonplan-assets.s3.amazonaws.com/docs/CarbonPlan-Form-990-2020.pdf'>
+              <Link href='https://files.carbonplan.org/CarbonPlan-Form-990-2020.pdf'>
                 2020 Form 990
               </Link>
               .

--- a/pages/index.js
+++ b/pages/index.js
@@ -150,7 +150,7 @@ const Index = () => {
                   Annual report
                 </Box>
                 <Button
-                  href='https://carbonplan-assets.s3.amazonaws.com/docs/CarbonPlan-Annual-Report-2020.pdf'
+                  href='https://files.carbonplan.org/CarbonPlan-Annual-Report-2020.pdf'
                   size='md'
                   sx={{ mb: [3] }}
                   suffix={<RotatingArrow />}


### PR DESCRIPTION
This PR updates the links for our shared files to use our new CDN URL at `files.carbonplan.org` instead of the direct S3 link `carbonplan-assets.s3.amazonaws.com/docs/`. The linked files are identical.