### PR TITLE
design routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -35,6 +35,10 @@
     {
       "source": "/data(.*)",
       "destination": "https://data.carbonplan.org/data$1"
+    },
+    {
+      "source": "/design(.*)",
+      "destination": "https://design.carbonplan.org/design$1"
     }
   ],
   "redirects": [


### PR DESCRIPTION
Simple routing change so that `carbonplan.org/design` routes to our standalone design site at `design.carbonplan.org`.