### PR TITLE
add 2022 to press page

### DIFF
--- a/pages/press.js
+++ b/pages/press.js
@@ -111,6 +111,7 @@ const initFormat = {
 const initYear = {
   2020: true,
   2021: true,
+  2022: true,
 }
 
 const Press = () => {


### PR DESCRIPTION
Making sure 2022 entries show up on the press page by adding 2022 as an option.