### PR TITLE
routing update

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -21,12 +21,12 @@
       "destination": "https://forest-offsets.carbonplan.org/research/forest-offsets"
     },
     {
-      "source": "/research/forest-offsets-fires(.*)",
-      "destination": "https://forest-offsets.carbonplan.org/research/forest-offsets-fires$1"
-    },
-    {
       "source": "/research/forest-offsets-crediting(.*)",
       "destination": "https://forest-offsets.carbonplan.org/research/forest-offsets-crediting$1"
+    },
+    {
+      "source": "/research/forest-offsets-fires(.*)",
+      "destination": "https://forest-offsets.carbonplan.org/research/forest-offsets-fires$1"
     },
     {
       "source": "/research/seaweed-farming/embed",

--- a/vercel.json
+++ b/vercel.json
@@ -17,8 +17,12 @@
       "destination": "https://forest-carbon.carbonplan.org/research/forest-carbon"
     },
     {
-      "source": "/research/forest-offsets",
-      "destination": "https://forest-offsets.carbonplan.org/research/forest-offsets"
+      "source": "/research/forest-offsets-fires(.*)",
+      "destination": "https://forest-offsets.carbonplan.org/research/forest-offsets-fires$1"
+    },
+    {
+      "source": "/research/forest-offsets-crediting(.*)",
+      "destination": "https://forest-offsets.carbonplan.org/research/forest-offsets-crediting$1"
     },
     {
       "source": "/research/seaweed-farming/embed",
@@ -64,7 +68,7 @@
     },
     {
       "source": "/research/forest-offsets-map",
-      "destination": "https://carbonplan.org/research/forest-offsets"
+      "destination": "https://carbonplan.org/research/forest-offsets-crediting"
     },
     {
       "source": "/reports/methods",

--- a/vercel.json
+++ b/vercel.json
@@ -17,6 +17,10 @@
       "destination": "https://forest-carbon.carbonplan.org/research/forest-carbon"
     },
     {
+      "source": "/research/forest-offsets",
+      "destination": "https://forest-offsets.carbonplan.org/research/forest-offsets"
+    },
+    {
       "source": "/research/forest-offsets-fires(.*)",
       "destination": "https://forest-offsets.carbonplan.org/research/forest-offsets-fires$1"
     },


### PR DESCRIPTION
Updates routes to the new split sub pages `forest-offsets-fires` and `forest-offsets-crediting`. Also update an old redirect that I doubt ever gets used, but might as well.