### PR TITLE
switch to plausible analytics

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,7 @@
-module.exports = {
+const { withPlausibleProxy } = require('next-plausible')
+
+module.exports = withPlausibleProxy()({
   experimental: {
     scrollRestoration: true,
   },
-}
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "d3-shape": "^3.0.1",
         "lru-cache": "^6.0.0",
         "next": "^14.2.22",
+        "next-plausible": "^3.12.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-google-recaptcha": "^2.1.0",
@@ -5471,6 +5472,20 @@
         }
       }
     },
+    "node_modules/next-plausible": {
+      "version": "3.12.4",
+      "resolved": "https://registry.npmjs.org/next-plausible/-/next-plausible-3.12.4.tgz",
+      "integrity": "sha512-cD3+ixJxf8yBYvsideTxqli3fvrB7R4BXcvsNJz8Sm2X1QN039WfiXjCyNWkub4h5++rRs6fHhchUMnOuJokcg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/4lejandrito/next-plausible?sponsor=1"
+      },
+      "peerDependencies": {
+        "next": "^11.1.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 ",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -10874,6 +10889,12 @@
         "postcss": "8.4.31",
         "styled-jsx": "5.1.1"
       }
+    },
+    "next-plausible": {
+      "version": "3.12.4",
+      "resolved": "https://registry.npmjs.org/next-plausible/-/next-plausible-3.12.4.tgz",
+      "integrity": "sha512-cD3+ixJxf8yBYvsideTxqli3fvrB7R4BXcvsNJz8Sm2X1QN039WfiXjCyNWkub4h5++rRs6fHhchUMnOuJokcg==",
+      "requires": {}
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "d3-shape": "^3.0.1",
     "lru-cache": "^6.0.0",
     "next": "^14.2.22",
+    "next-plausible": "^3.12.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-google-recaptcha": "^2.1.0",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,3 +1,5 @@
+import React from 'react'
+import PlausibleProvider from 'next-plausible'
 import { ThemeProvider } from 'theme-ui'
 import theme from '@carbonplan/theme'
 import '@carbonplan/components/globals.css'
@@ -5,8 +7,14 @@ import '@carbonplan/components/fonts.css'
 
 export default function App({ Component, pageProps }) {
   return (
-    <ThemeProvider theme={theme}>
-      <Component {...pageProps} />
-    </ThemeProvider>
+    <PlausibleProvider
+      domain='carbonplan.org'
+      trackOutboundLinks={true}
+      trackFileDownloads={true}
+    >
+      <ThemeProvider theme={theme}>
+        <Component {...pageProps} />
+      </ThemeProvider>
+    </PlausibleProvider>
   )
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -9,8 +9,8 @@ export default function App({ Component, pageProps }) {
   return (
     <PlausibleProvider
       domain='carbonplan.org'
-      trackOutboundLinks={true}
-      trackFileDownloads={true}
+      trackOutboundLinks
+      trackFileDownloads
     >
       <ThemeProvider theme={theme}>
         <Component {...pageProps} />

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,12 +1,14 @@
-import React from 'react'
 import Document, { Html, Main, NextScript, Head } from 'next/document'
+import { Tracking } from '@carbonplan/components'
 import { InitializeColorMode } from 'theme-ui'
 
 class MyDocument extends Document {
   render() {
     return (
       <Html lang='en' className='no-focus-outline'>
-        <Head />
+        <Head>
+          <Tracking id={process.env.GA_TRACKING_ID} />
+        </Head>
         <body>
           <InitializeColorMode />
           <Main />

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,14 +1,12 @@
+import React from 'react'
 import Document, { Html, Main, NextScript, Head } from 'next/document'
-import { Tracking } from '@carbonplan/components'
 import { InitializeColorMode } from 'theme-ui'
 
 class MyDocument extends Document {
   render() {
     return (
       <Html lang='en' className='no-focus-outline'>
-        <Head>
-          <Tracking id={process.env.GA_TRACKING_ID} />
-        </Head>
+        <Head />
         <body>
           <InitializeColorMode />
           <Main />

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,12 +1,5 @@
-import { Box, Image } from 'theme-ui'
-import {
-  Layout,
-  Row,
-  Column,
-  Button,
-  Link,
-  formatDate,
-} from '@carbonplan/components'
+import { Box } from 'theme-ui'
+import { Layout, Row, Column, Button, Link } from '@carbonplan/components'
 import { RotatingArrow } from '@carbonplan/icons'
 import { keyframes } from '@emotion/react'
 import Splash from '../components/splash'


### PR DESCRIPTION
This moves responsibility for analytics setup out of the `Tracking` component from `@carbonplan/components` and to the `next-plausible` provider wrapping the app. 