### PR TITLE
vercel.json: oae-efficiency -> mcdr-tools rewrite

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
     },
     {
       "source": "/research/oae-efficiency(.*)",
-      "destination": "https://oae-efficiency.carbonplan.org/research/oae-efficiency$1"
+      "destination": "https://mcdr-tools.carbonplan.org/research/oae-efficiency$1"
     },
     {
       "source": "/research/offsets-db-explainer",


### PR DESCRIPTION
This is an incremental part of our release of the combined DOR/OAE tool setup. We're renaming the repo and subdomain to mcdr-tools. Merge to be coordinated with https://github.com/carbonplan/oae-web/pull/79