### PR TITLE
Add site-wide search page

### DIFF
--- a/data/pages.js
+++ b/data/pages.js
@@ -1,0 +1,60 @@
+export const PAGES = {
+  about: {
+    title: 'About – CarbonPlan',
+    description:
+      'We’re a nonprofit that analyzes climate solutions based on the best available science and data.',
+  },
+  funding: {
+    title: 'Funding – CarbonPlan',
+    description:
+      'Public list of all our sources of unrestricted or project-specific funding greater than $1000.',
+  },
+  faq: {
+    title: 'FAQ – CarbonPlan',
+    description:
+      'Frequently asked questions about our work and our organization.',
+  },
+  team: {
+    title: 'Team – CarbonPlan',
+    description: 'Meet our core team and our Board of Directors.',
+  },
+  press: {
+    title: 'Press – CarbonPlan',
+    description:
+      'Complete list of press that has either covered our work or featured members of our team.',
+  },
+  donate: {
+    title: 'Donate – CarbonPlan',
+    description:
+      'Make a donation to support our mission of using data and science for climate action.',
+  },
+  disclosures: {
+    title: 'Disclosures – CarbonPlan',
+    description:
+      'State-specific disclosures for nonprofit organizations soliciting contributions.',
+  },
+  privacy: {
+    title: 'Privacy – CarbonPlan',
+    description:
+      'Privacy policy that explains our information collection, use, and sharing practices.',
+  },
+  terms: {
+    title: 'Terms – CarbonPlan',
+    description:
+      'Terms of use related to our website, code, data, and content.',
+  },
+  design: {
+    title: 'Design – CarbonPlan',
+    description: 'Documentation for our design system and component library.',
+  },
+  data: {
+    title: 'Data – CarbonPlan',
+    description:
+      'A catalog of public datasets produced throughout our work. Not a frequently updated resource.',
+  },
+  search: {
+    title: 'Search – CarbonPlan',
+    description:
+      'Search for research and other resources across the CarbonPlan website.',
+  },
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@carbonplan/components": "13.4.0-develop.2",
+        "@carbonplan/components": "13.4.0-develop.3",
         "@carbonplan/emoji": "^2.0.0",
         "@carbonplan/icons": "^2.0.0",
         "@carbonplan/theme": "^7.0.0",
@@ -531,9 +531,9 @@
       "dev": true
     },
     "node_modules/@carbonplan/components": {
-      "version": "13.4.0-develop.2",
-      "resolved": "https://registry.npmjs.org/@carbonplan/components/-/components-13.4.0-develop.2.tgz",
-      "integrity": "sha512-rg4oHBYqas3TVpxJgqqGbhAslIoQ9QDDYdw5L6xV9sg3qgB7InE/MQklEnfktnFBmSWsGGbX1z9lTS4aTivcuA==",
+      "version": "13.4.0-develop.3",
+      "resolved": "https://registry.npmjs.org/@carbonplan/components/-/components-13.4.0-develop.3.tgz",
+      "integrity": "sha512-0kWaBf9RlJ9KS99fiNfalKB1K6gUvQ1mlkACD2Rbttklv5gEpLuXwEzNUIBqSItBfg+g8rcLWYfKftdjpOO7hA==",
       "license": "MIT",
       "dependencies": {
         "@carbonplan/emoji": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@carbonplan/components": "^13.2.1",
+        "@carbonplan/components": "^13.4.0-develop.0",
         "@carbonplan/emoji": "^2.0.0",
         "@carbonplan/icons": "^2.0.0",
         "@carbonplan/theme": "^7.0.0",
@@ -531,9 +531,9 @@
       "dev": true
     },
     "node_modules/@carbonplan/components": {
-      "version": "13.2.1",
-      "resolved": "https://registry.npmjs.org/@carbonplan/components/-/components-13.2.1.tgz",
-      "integrity": "sha512-YgHLISSqvyGHcwmpMuGa/K3/vQjnMoG82fhrnXYYU2+mJfEkpW+3M/xDx697Nl7w5PlQP1TRIklTxhjXmgYh3w==",
+      "version": "13.4.0-develop.0",
+      "resolved": "https://registry.npmjs.org/@carbonplan/components/-/components-13.4.0-develop.0.tgz",
+      "integrity": "sha512-eUfajeoeu/wWVLqc/HPevg5ndPQ09AKt5Lq2TCwtF9iCWspUs1fj0IBUtUrUvUy4/lqfpAriMzTwSGslXkcmOw==",
       "license": "MIT",
       "dependencies": {
         "@carbonplan/emoji": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@carbonplan/components": "^13.4.0-develop.0",
+        "@carbonplan/components": "13.4.0-develop.1",
         "@carbonplan/emoji": "^2.0.0",
         "@carbonplan/icons": "^2.0.0",
         "@carbonplan/theme": "^7.0.0",
@@ -531,9 +531,9 @@
       "dev": true
     },
     "node_modules/@carbonplan/components": {
-      "version": "13.4.0-develop.0",
-      "resolved": "https://registry.npmjs.org/@carbonplan/components/-/components-13.4.0-develop.0.tgz",
-      "integrity": "sha512-eUfajeoeu/wWVLqc/HPevg5ndPQ09AKt5Lq2TCwtF9iCWspUs1fj0IBUtUrUvUy4/lqfpAriMzTwSGslXkcmOw==",
+      "version": "13.4.0-develop.1",
+      "resolved": "https://registry.npmjs.org/@carbonplan/components/-/components-13.4.0-develop.1.tgz",
+      "integrity": "sha512-29P7L4Fjh4Sz+8MUw20Tu3VyzXoCxqSfj/YFXEVnL5LcIPC3BpZUG03+CCyHbBwtbcdh7Zas5VOIQQqywmgC/Q==",
       "license": "MIT",
       "dependencies": {
         "@carbonplan/emoji": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@carbonplan/components": "13.4.0-develop.1",
+        "@carbonplan/components": "13.4.0-develop.2",
         "@carbonplan/emoji": "^2.0.0",
         "@carbonplan/icons": "^2.0.0",
         "@carbonplan/theme": "^7.0.0",
@@ -531,9 +531,9 @@
       "dev": true
     },
     "node_modules/@carbonplan/components": {
-      "version": "13.4.0-develop.1",
-      "resolved": "https://registry.npmjs.org/@carbonplan/components/-/components-13.4.0-develop.1.tgz",
-      "integrity": "sha512-29P7L4Fjh4Sz+8MUw20Tu3VyzXoCxqSfj/YFXEVnL5LcIPC3BpZUG03+CCyHbBwtbcdh7Zas5VOIQQqywmgC/Q==",
+      "version": "13.4.0-develop.2",
+      "resolved": "https://registry.npmjs.org/@carbonplan/components/-/components-13.4.0-develop.2.tgz",
+      "integrity": "sha512-rg4oHBYqas3TVpxJgqqGbhAslIoQ9QDDYdw5L6xV9sg3qgB7InE/MQklEnfktnFBmSWsGGbX1z9lTS4aTivcuA==",
       "license": "MIT",
       "dependencies": {
         "@carbonplan/emoji": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@carbonplan/components": "13.4.0-develop.3",
+        "@carbonplan/components": "^13.2.1",
         "@carbonplan/emoji": "^2.0.0",
         "@carbonplan/icons": "^2.0.0",
         "@carbonplan/theme": "^7.0.0",
@@ -531,9 +531,9 @@
       "dev": true
     },
     "node_modules/@carbonplan/components": {
-      "version": "13.4.0-develop.3",
-      "resolved": "https://registry.npmjs.org/@carbonplan/components/-/components-13.4.0-develop.3.tgz",
-      "integrity": "sha512-0kWaBf9RlJ9KS99fiNfalKB1K6gUvQ1mlkACD2Rbttklv5gEpLuXwEzNUIBqSItBfg+g8rcLWYfKftdjpOO7hA==",
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/@carbonplan/components/-/components-13.3.1.tgz",
+      "integrity": "sha512-M3hhWGf8bf+sLsmrcx/vNOFL4OJvET+fhTRExQaxmnRtP/Kee9xEXqenttzp4d0ZUJ1VurWk1vlE+CuCF26GWA==",
       "license": "MIT",
       "dependencies": {
         "@carbonplan/emoji": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/carbonplan/carbonplan.org#readme",
   "dependencies": {
-    "@carbonplan/components": "13.4.0-develop.2",
+    "@carbonplan/components": "13.4.0-develop.3",
     "@carbonplan/emoji": "^2.0.0",
     "@carbonplan/icons": "^2.0.0",
     "@carbonplan/theme": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/carbonplan/carbonplan.org#readme",
   "dependencies": {
-    "@carbonplan/components": "^13.2.1",
+    "@carbonplan/components": "13.4.0-develop.0",
     "@carbonplan/emoji": "^2.0.0",
     "@carbonplan/icons": "^2.0.0",
     "@carbonplan/theme": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/carbonplan/carbonplan.org#readme",
   "dependencies": {
-    "@carbonplan/components": "13.4.0-develop.0",
+    "@carbonplan/components": "13.4.0-develop.1",
     "@carbonplan/emoji": "^2.0.0",
     "@carbonplan/icons": "^2.0.0",
     "@carbonplan/theme": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/carbonplan/carbonplan.org#readme",
   "dependencies": {
-    "@carbonplan/components": "13.4.0-develop.3",
+    "@carbonplan/components": "^13.2.1",
     "@carbonplan/emoji": "^2.0.0",
     "@carbonplan/icons": "^2.0.0",
     "@carbonplan/theme": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/carbonplan/carbonplan.org#readme",
   "dependencies": {
-    "@carbonplan/components": "13.4.0-develop.1",
+    "@carbonplan/components": "13.4.0-develop.2",
     "@carbonplan/emoji": "^2.0.0",
     "@carbonplan/icons": "^2.0.0",
     "@carbonplan/theme": "^7.0.0",

--- a/pages/about.js
+++ b/pages/about.js
@@ -9,8 +9,9 @@ import {
   Heading,
 } from '@carbonplan/components'
 import { RotatingArrow } from '@carbonplan/icons'
-import { highlights, press } from '../data/recent'
 import { keyframes } from '@emotion/react'
+import { highlights, press } from '../data/recent'
+import { PAGES } from '../data/pages'
 
 const sx = {
   link: {
@@ -29,11 +30,9 @@ const About = () => {
   return (
     <Layout
       links={'homepage'}
-      title={'About – CarbonPlan'}
+      title={PAGES.about.title}
       nav={'about'}
-      description={
-        'We’re a nonprofit that analyzes climate solutions based on the best available science and data.'
-      }
+      description={PAGES.about.description}
     >
       <Heading>About</Heading>
       <Box sx={{ display: ['none', 'none', 'initial', 'initial'] }}>

--- a/pages/disclosures.js
+++ b/pages/disclosures.js
@@ -1,15 +1,14 @@
 import { Box } from 'theme-ui'
 
 import { Layout, Row, Column, Link, Heading } from '@carbonplan/components'
+import { PAGES } from '../data/pages'
 
 const Disclosures = () => {
   return (
     <Layout
       links={'homepage'}
-      title={'Disclosures – CarbonPlan'}
-      description={
-        'State-specific disclosures for nonprofit organizations soliciting contributions.'
-      }
+      title={PAGES.disclosures.title}
+      description={PAGES.disclosures.description}
     >
       <Heading>Disclosures</Heading>
       <Row>

--- a/pages/donate.js
+++ b/pages/donate.js
@@ -12,6 +12,7 @@ import {
   Heading,
 } from '@carbonplan/components'
 import { RotatingArrow } from '@carbonplan/icons'
+import { PAGES } from '../data/pages'
 
 // Specific errors expected and the corresponding `status` passed to `Layout`
 const STATUSES = {
@@ -241,11 +242,9 @@ const Donate = () => {
   return (
     <Layout
       links={'homepage'}
-      title={'Donate – CarbonPlan'}
+      title={PAGES.donate.title}
       status={status}
-      description={
-        'Make a donation to support our mission of using data and science for climate action.'
-      }
+      description={PAGES.donate.description}
     >
       <Heading sidenote={<Sidenote />}>Donate</Heading>
       <Row>

--- a/pages/faq.js
+++ b/pages/faq.js
@@ -8,16 +8,15 @@ import {
   Link,
   Heading,
 } from '@carbonplan/components'
+import { PAGES } from '../data/pages'
 
 const FAQ = () => {
   return (
     <Layout
       links={'homepage'}
-      title={'FAQ – CarbonPlan'}
+      title={PAGES.faq.title}
       nav={'faq'}
-      description={
-        'Frequently asked questions about our work and our organization.'
-      }
+      description={PAGES.faq.description}
     >
       <Heading>FAQ</Heading>
       <Question first>Are you a nonprofit?</Question>

--- a/pages/funding.js
+++ b/pages/funding.js
@@ -2,15 +2,14 @@ import { Box } from 'theme-ui'
 import { Layout, Row, Column, Link, Heading } from '@carbonplan/components'
 import AnnotatedTable from '../components/annotated-table'
 import { unrestricted, projectSpecific, partners } from '../data/funding'
+import { PAGES } from '../data/pages'
 
 const Funding = () => {
   return (
     <Layout
       links={'homepage'}
-      title={'Funding – CarbonPlan'}
-      description={
-        'Public list of all our sources of unrestricted or project-specific funding greater than $1000.'
-      }
+      title={PAGES.funding.title}
+      description={PAGES.funding.description}
     >
       <Heading
         sidenote={

--- a/pages/press.js
+++ b/pages/press.js
@@ -13,6 +13,7 @@ import {
 } from '@carbonplan/components'
 import { Arrow } from '@carbonplan/icons'
 import { highlights, press } from '../data/press'
+import { PAGES } from '../data/pages'
 import LOGOS from '../components/press-logos'
 
 const sx = {
@@ -141,10 +142,8 @@ const Press = () => {
   return (
     <Layout
       links={'homepage'}
-      title={'Press – CarbonPlan'}
-      description={
-        'Complete list of press that has either covered our work or featured members of our team.'
-      }
+      title={PAGES.press.title}
+      description={PAGES.press.description}
       dimmer={'bottom'}
       settings={{ value: expanded, onClick: () => setExpanded(!expanded) }}
       nav={'press'}

--- a/pages/privacy.js
+++ b/pages/privacy.js
@@ -1,14 +1,13 @@
 import { Box } from 'theme-ui'
 import { Layout, Row, Column, Link, Heading } from '@carbonplan/components'
+import { PAGES } from '../data/pages'
 
 const Privacy = () => {
   return (
     <Layout
       links={'homepage'}
-      title={'Privacy – CarbonPlan'}
-      description={
-        'Privacy policy that explains our information collection, use, and sharing practices.'
-      }
+      title={PAGES.privacy.title}
+      description={PAGES.privacy.description}
     >
       <Heading>Privacy policy</Heading>
       <Row>

--- a/pages/search.js
+++ b/pages/search.js
@@ -11,6 +11,7 @@ import {
 import { X } from '@carbonplan/icons'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useRouter } from 'next/router'
+import { PAGES } from '../data/pages'
 
 const sx = {
   label: {
@@ -40,6 +41,8 @@ const normalizeText = (str) => {
   return str?.toLowerCase()?.replace(/-/g, ' ')
 }
 
+const { search, ...STATIC_PAGES } = PAGES
+
 const Search = ({ contents }) => {
   const router = useRouter()
   const inputRef = useRef(null)
@@ -58,7 +61,6 @@ const Search = ({ contents }) => {
 
   const results = useMemo(() => {
     return contents
-      .filter((c) => c.date)
       .filter((c) => {
         if (!query) return true
         const terms = normalizeText(query).split(/\s+/).filter(Boolean)
@@ -107,10 +109,8 @@ const Search = ({ contents }) => {
   return (
     <Layout
       links={'homepage'}
-      title={'Search – CarbonPlan'}
-      description={
-        'Search for research and other resources across the CarbonPlan website.'
-      }
+      title={search.title}
+      description={search.description}
     >
       <Row sx={{ mt: [5, 6, 7, 8], mb: [5, 6, 7, 8], ...sx }}>
         <Column start={[1, 2, 2, 2]} width={[6, 2, 3, 3]}>
@@ -249,15 +249,6 @@ const EXTRA_CONTENT = [
     },
   },
   {
-    page: 'https://carbonplan.org/data',
-    date: '2024-03-08',
-    metadata: {
-      title: 'CarbonPlan datasets',
-      summary:
-        'A catalog of public datasets produced throughout our work. Not a frequently updated resource.',
-    },
-  },
-  {
     page: 'https://carbonplan.org/data/zarr-access',
     date: '2023-10-23',
     metadata: {
@@ -296,7 +287,16 @@ export const getStaticProps = async () => {
     ).then((res) => res.json()),
   ])
 
-  const contents = [...research, ...blog, ...vcl, ...EXTRA_CONTENT]
+  const contents = [
+    ...research,
+    ...blog,
+    ...vcl,
+    ...Object.entries(STATIC_PAGES).map(([page, { title, description }]) => ({
+      page,
+      metadata: { title, summary: description },
+    })),
+    ...EXTRA_CONTENT,
+  ]
     .filter((el) => el.metadata)
     .map((el) =>
       el.metadata.authors

--- a/pages/search.js
+++ b/pages/search.js
@@ -282,14 +282,14 @@ const EXTRA_CONTENT = [
 
 export const getStaticProps = async () => {
   const [research, blog, vcl] = await Promise.all([
+    fetch('https://carbonplan.org/research/contents.json').then((res) =>
+      res.json()
+    ),
+    fetch('https://carbonplan.org/blog/contents.json').then((res) =>
+      res.json()
+    ),
     fetch(
-      'https://research-git-katamartin-metadata-carbonplan.vercel.app/research/contents.json'
-    ).then((res) => res.json()),
-    fetch(
-      'https://blog-git-katamartin-metadata-carbonplan.vercel.app/blog/contents.json'
-    ).then((res) => res.json()),
-    fetch(
-      'https://cdr-mrv-git-katamartin-metadata-carbonplan.vercel.app/research/cdr-verification/contents.json'
+      'https://carbonplan.org/research/cdr-verification/contents.json'
     ).then((res) => res.json()),
   ])
 

--- a/pages/search.js
+++ b/pages/search.js
@@ -1,4 +1,4 @@
-import { Box, Divider, Flex } from 'theme-ui'
+import { Box, Divider, Flex, IconButton } from 'theme-ui'
 import {
   Layout,
   Row,
@@ -8,7 +8,8 @@ import {
   formatDate,
   Input,
 } from '@carbonplan/components'
-import { useEffect, useMemo, useState } from 'react'
+import { X } from '@carbonplan/icons'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useRouter } from 'next/router'
 
 const sx = {
@@ -41,6 +42,7 @@ const normalizeText = (str) => {
 
 const Search = ({ contents }) => {
   const router = useRouter()
+  const inputRef = useRef(null)
   const [query, setQuery] = useState(router.query.query ?? null)
   const [sort, setSort] = useState({
     newest: true,
@@ -144,19 +146,44 @@ const Search = ({ contents }) => {
                 >
                   Query
                 </Box>
-                <Input
-                  value={query ?? ''}
-                  onChange={(e) => setQuery(e.target.value)}
-                  size='xs'
-                  sx={{
-                    mt: ['-12px', 3, 3, 3],
-                    width: '100%',
-                    fontFamily: 'mono',
-                    letterSpacing: 'mono',
-                    fontSize: [1, 1, 1, 2],
-                    textTransform: 'uppercase',
-                  }}
-                />
+                <Box sx={{ position: 'relative' }}>
+                  <Input
+                    ref={inputRef}
+                    value={query ?? ''}
+                    onChange={(e) => setQuery(e.target.value)}
+                    size='xs'
+                    sx={{
+                      mt: ['-12px', 3, 3, 3],
+                      width: '100%',
+                      fontFamily: 'mono',
+                      letterSpacing: 'mono',
+                      fontSize: [1, 1, 1, 2],
+                      textTransform: 'uppercase',
+                    }}
+                  />
+                  <IconButton
+                    onClick={() => {
+                      setQuery('')
+                      inputRef.current?.focus()
+                    }}
+                    aria-label='Clear search'
+                    sx={{
+                      p: 0,
+                      position: 'absolute',
+                      right: [-2, -2, -5, -5],
+                      top: [-2, -1, 0, 0],
+                      cursor: 'pointer',
+                      color: 'secondary',
+                      opacity: query ? 1 : 0,
+                      transition: 'all 0.2s',
+                      '&:hover': {
+                        color: 'primary',
+                      },
+                    }}
+                  >
+                    <X sx={{ width: 16 }} />
+                  </IconButton>
+                </Box>
               </Box>
             </Box>
             <Filter values={sort} setValues={setSort} label='Sort by' />

--- a/pages/search.js
+++ b/pages/search.js
@@ -34,6 +34,11 @@ const getType = (page, metadata) => {
   return type
 }
 
+const normalizeText = (str) => {
+  if (!str) return ''
+  return str?.toLowerCase()?.replace(/-/g, ' ')
+}
+
 const Search = ({ contents }) => {
   const router = useRouter()
   const [query, setQuery] = useState(router.query.query ?? null)
@@ -52,16 +57,19 @@ const Search = ({ contents }) => {
   const results = useMemo(() => {
     return contents
       .filter((c) => c.date)
-      .filter((c) =>
-        query
-          ? [
-              c.page,
-              c.metadata.title,
-              c.metadata.summary,
-              ...(c.metadata.authors ? c.metadata.authors : []),
-            ].some((text) => text?.toLowerCase().includes(query.toLowerCase()))
-          : true
-      )
+      .filter((c) => {
+        if (!query) return true
+        const terms = normalizeText(query).split(/\s+/).filter(Boolean)
+        const result = [
+          c.page,
+          c.metadata.title,
+          c.metadata.summary,
+          ...(c.metadata.authors ?? []),
+        ]
+          .map(normalizeText)
+          .join(' ')
+        return terms.every((term) => result.includes(term))
+      })
       .filter((c) =>
         filter.hasOwnProperty(c.metadata.type)
           ? filter[c.metadata.type]

--- a/pages/search.js
+++ b/pages/search.js
@@ -174,7 +174,11 @@ const Search = ({ contents }) => {
               </Box>
               <Box sx={{ variant: 'styles.h3', mt: 4, mb: 3 }}>
                 <Link
-                  href={`https://carbonplan.org/${page}`}
+                  href={
+                    page.includes('https://')
+                      ? page
+                      : `https://carbonplan.org/${page}`
+                  }
                   sx={{ textDecoration: 'none' }}
                 >
                   {metadata.title}

--- a/pages/search.js
+++ b/pages/search.js
@@ -186,13 +186,13 @@ const Search = ({ contents }) => {
                 </Box>
               </Box>
             </Box>
-            <Filter values={sort} setValues={setSort} label='Sort by' />
             <Filter
               values={filter}
               setValues={setFilter}
               label='Filter by type'
               showAll
             />
+            <Filter values={sort} setValues={setSort} label='Sort by' />
           </Flex>
         </Column>
         <Column start={[1, 4, 5, 5]} width={[6, 4, 5, 5]}>
@@ -207,7 +207,8 @@ const Search = ({ contents }) => {
               <Box key={page}>
                 {i > 0 && <Divider sx={{ my: 4 }} />}
                 <Box sx={sx.label}>
-                  {date && formatDate(date)} / {getType(page, metadata)}
+                  {date && `${formatDate(date)} / `}
+                  {getType(page, metadata)}
                 </Box>
                 <Box sx={{ variant: 'styles.h3', mt: 4, mb: 3 }}>
                   <Link

--- a/pages/search.js
+++ b/pages/search.js
@@ -127,8 +127,9 @@ const Search = ({ contents }) => {
               pb: '4px',
             }}
           >
-            {typeof query === 'string' &&
-              `There are ${results.length} results that match your search.`}
+            {typeof query === 'string'
+              ? `There are ${results.length} results that match your search.`
+              : 'Enter a query to filter results.'}
           </Flex>
         </Column>
       </Row>
@@ -202,40 +203,40 @@ const Search = ({ contents }) => {
           {results.length === 0 && (
             <Box sx={{ ...sx.label }}>No results found</Box>
           )}
-          {typeof query === 'string' &&
-            results.map(({ page, date, metadata }, i) => (
-              <Box key={page}>
-                {i > 0 && <Divider sx={{ my: 4 }} />}
-                <Box sx={sx.label}>
-                  {date && `${formatDate(date)} / `}
-                  {getType(page, metadata)}
-                </Box>
-                <Box sx={{ variant: 'styles.h3', mt: 4, mb: 3 }}>
-                  <Link
-                    href={
-                      page.includes('https://')
-                        ? page
-                        : `https://carbonplan.org/${page}`
-                    }
-                    sx={{
-                      textDecoration: 'none',
-                      transition: 'color 0.2s',
-                      '&:hover': { color: metadata.color ?? 'secondary' },
-                    }}
-                  >
-                    {metadata.title}
-                  </Link>
-                </Box>
 
-                <Box>{metadata.summary}</Box>
-
-                {metadata.authors?.length > 0 && (
-                  <Box sx={{ ...sx.label, mt: 3 }}>
-                    {metadata.authors?.join(' + ')}
-                  </Box>
-                )}
+          {results.map(({ page, date, metadata }, i) => (
+            <Box key={page}>
+              {i > 0 && <Divider sx={{ my: 4 }} />}
+              <Box sx={sx.label}>
+                {date && `${formatDate(date)} / `}
+                {getType(page, metadata)}
               </Box>
-            ))}
+              <Box sx={{ variant: 'styles.h3', mt: 4, mb: 3 }}>
+                <Link
+                  href={
+                    page.includes('https://')
+                      ? page
+                      : `https://carbonplan.org/${page}`
+                  }
+                  sx={{
+                    textDecoration: 'none',
+                    transition: 'color 0.2s',
+                    '&:hover': { color: metadata.color ?? 'secondary' },
+                  }}
+                >
+                  {metadata.title}
+                </Link>
+              </Box>
+
+              <Box>{metadata.summary}</Box>
+
+              {metadata.authors?.length > 0 && (
+                <Box sx={{ ...sx.label, mt: 3 }}>
+                  {metadata.authors?.join(' + ')}
+                </Box>
+              )}
+            </Box>
+          ))}
         </Column>
       </Row>
     </Layout>

--- a/pages/search.js
+++ b/pages/search.js
@@ -46,7 +46,7 @@ const { search, ...STATIC_PAGES } = PAGES
 const Search = ({ contents }) => {
   const router = useRouter()
   const inputRef = useRef(null)
-  const [query, setQuery] = useState(router.query.query ?? null)
+  const [query, setQuery] = useState(null)
   const [sort, setSort] = useState({
     newest: true,
     oldest: false,
@@ -59,11 +59,18 @@ const Search = ({ contents }) => {
     other: true,
   })
 
+  const effectiveQuery =
+    query ??
+    (router.isReady && typeof router.query.query === 'string'
+      ? router.query.query
+      : null)
+
   const results = useMemo(() => {
+    if (!router.isReady) return []
     return contents
       .filter((c) => {
-        if (!query) return true
-        const terms = normalizeText(query).split(/\s+/).filter(Boolean)
+        if (!effectiveQuery) return true
+        const terms = normalizeText(effectiveQuery).split(/\s+/).filter(Boolean)
         const result = [
           c.page,
           c.metadata.title,
@@ -82,13 +89,7 @@ const Search = ({ contents }) => {
       .sort(
         (a, b) => (new Date(b.date) - new Date(a.date)) * (sort.oldest ? -1 : 1)
       )
-  }, [contents, sort, filter, query])
-
-  useEffect(() => {
-    if (router.isReady && router.query.query && typeof query !== 'string') {
-      setQuery(router.query.query)
-    }
-  }, [router])
+  }, [contents, sort, filter, effectiveQuery, router.isReady])
 
   useEffect(() => {
     if (typeof query === 'string') {
@@ -127,9 +128,10 @@ const Search = ({ contents }) => {
               pb: '4px',
             }}
           >
-            {typeof query === 'string'
-              ? `There are ${results.length} results that match your search.`
-              : 'Enter a query to filter results.'}
+            {router.isReady &&
+              (typeof effectiveQuery === 'string'
+                ? `There are ${results.length} results that match your search.`
+                : 'Enter a query to filter results.')}
           </Flex>
         </Column>
       </Row>
@@ -150,7 +152,7 @@ const Search = ({ contents }) => {
                 <Box sx={{ position: 'relative' }}>
                   <Input
                     ref={inputRef}
-                    value={query ?? ''}
+                    value={effectiveQuery ?? ''}
                     onChange={(e) => setQuery(e.target.value)}
                     size='xs'
                     sx={{
@@ -175,7 +177,7 @@ const Search = ({ contents }) => {
                       top: [-2, -1, 0, 0],
                       cursor: 'pointer',
                       color: 'secondary',
-                      opacity: query ? 1 : 0,
+                      opacity: effectiveQuery ? 1 : 0,
                       transition: 'all 0.2s',
                       '&:hover': {
                         color: 'primary',
@@ -200,7 +202,7 @@ const Search = ({ contents }) => {
           <Divider
             sx={{ my: 4, display: ['inherit', 'none', 'none', 'none'] }}
           />
-          {results.length === 0 && (
+          {typeof effectiveQuery === 'string' && results.length === 0 && (
             <Box sx={{ ...sx.label }}>No results found</Box>
           )}
 

--- a/pages/search.js
+++ b/pages/search.js
@@ -61,7 +61,7 @@ const Search = ({ contents }) => {
             ].some((text) =>
               text?.toLowerCase().includes(router.query.query.toLowerCase())
             )
-          : true
+          : false
       )
       .filter((c) =>
         filter.hasOwnProperty(c.metadata.type)
@@ -77,7 +77,9 @@ const Search = ({ contents }) => {
     <Layout
       links={'homepage'}
       title={'Search – CarbonPlan'}
-      description={'TK.'}
+      description={
+        'Search for research and other resources across the CarbonPlan website.'
+      }
     >
       <Row sx={{ mt: [5, 6, 7, 8], mb: [5, 6, 7, 8], ...sx }}>
         <Column start={[1, 1, 2, 2]} width={[6, 6, 3, 3]}>
@@ -93,7 +95,9 @@ const Search = ({ contents }) => {
               pb: '4px',
             }}
           >
-            There are {results.length} results that match your search.
+            {router.query.query
+              ? `There are ${results.length} results that match your search.`
+              : 'Enter a search query below to view results.'}
           </Flex>
         </Column>
       </Row>

--- a/pages/search.js
+++ b/pages/search.js
@@ -22,6 +22,18 @@ const sx = {
   },
 }
 
+const getType = (page, metadata) => {
+  let type = 'other'
+  if (page.includes('research/cdr-verification/')) {
+    return 'Verification Framework Tool'
+  } else if (metadata.type === 'commentary' && page.includes('files.')) {
+    type = 'comment letter'
+  } else if (metadata.type) {
+    type = metadata.type
+  }
+  return type
+}
+
 const Search = ({ contents }) => {
   const router = useRouter()
   const [sort, setSort] = useState({
@@ -132,10 +144,7 @@ const Search = ({ contents }) => {
             <Box key={page}>
               {i > 0 && <Divider sx={{ my: 4 }} />}
               <Box sx={sx.label}>
-                {date && formatDate(date)} /{' '}
-                {page.includes('research/cdr-verification/')
-                  ? 'Verification Framework Tool'
-                  : metadata.type ?? 'Other'}
+                {date && formatDate(date)} / {getType(page, metadata)}
               </Box>
               <Box sx={{ variant: 'styles.h3', mt: 4, mb: 3 }}>
                 <Link

--- a/pages/search.js
+++ b/pages/search.js
@@ -135,7 +135,7 @@ const Search = ({ contents }) => {
                 {date && formatDate(date)} /{' '}
                 {page.includes('research/cdr-verification/')
                   ? 'Verification Framework Tool'
-                  : metadata.type}
+                  : metadata.type ?? 'Other'}
               </Box>
               <Box sx={{ variant: 'styles.h3', mt: 4, mb: 3 }}>
                 <Link
@@ -163,6 +163,34 @@ const Search = ({ contents }) => {
 
 export default Search
 
+const EXTRA_CONTENT = [
+  {
+    page: 'https://docs.carbonplan.org',
+    date: '2021-10-29',
+    metadata: {
+      title: 'CarbonPlan Docs',
+      summary: "Documentation for the software projects we're building.",
+    },
+  },
+  {
+    page: 'https://carbonplan.org/data',
+    date: '2024-03-08',
+    metadata: {
+      title: 'CarbonPlan datasets',
+      summary:
+        'A catalog of public datasets produced throughout our work. Not a frequently updated resource.',
+    },
+  },
+  {
+    page: 'https://carbonplan.org/data/zarr-access',
+    date: '2023-10-23',
+    metadata: {
+      title: 'Working with Zarr data',
+      summary: 'Notes on accessing datasets stored in Zarr format.',
+    },
+  },
+]
+
 export const getStaticProps = async () => {
   const [research, blog, vcl] = await Promise.all([
     fetch(
@@ -176,7 +204,7 @@ export const getStaticProps = async () => {
     ).then((res) => res.json()),
   ])
 
-  const contents = [...research, ...blog, ...vcl]
+  const contents = [...research, ...blog, ...vcl, ...EXTRA_CONTENT]
     .filter((el) => el.metadata)
     .map((el) =>
       el.metadata.authors
@@ -184,6 +212,7 @@ export const getStaticProps = async () => {
             ...el,
             metadata: {
               ...el.metadata,
+              // normalize authors to remove collaborator avatar configuration
               authors: el.metadata.authors.map((a) =>
                 typeof a === 'string' ? a : a.name
               ),

--- a/pages/search.js
+++ b/pages/search.js
@@ -65,9 +65,7 @@ const Search = ({ contents }) => {
     <Layout
       links={'homepage'}
       title={'Search – CarbonPlan'}
-      description={
-        'Public list of all our sources of unrestricted or project-specific funding greater than $1000.'
-      }
+      description={'TK.'}
     >
       <Row sx={{ mt: [5, 6, 7, 8], mb: [5, 6, 7, 8], ...sx }}>
         <Column start={[1, 1, 2, 2]} width={[6, 6, 3, 3]}>
@@ -83,7 +81,7 @@ const Search = ({ contents }) => {
               pb: '4px',
             }}
           >
-            There {results.length} results that match your search.
+            There are {results.length} results that match your search.
           </Flex>
         </Column>
       </Row>
@@ -130,10 +128,14 @@ const Search = ({ contents }) => {
           </Flex>
         </Column>
         <Column start={[1, 1, 5, 5]} width={[6, 5, 5, 5]}>
-          {results.map(({ page, date, metadata }) => (
+          {results.map(({ page, date, metadata }, i) => (
             <Box key={page}>
+              {i > 0 && <Divider sx={{ my: 4 }} />}
               <Box sx={sx.label}>
-                {date && formatDate(date)} / {metadata.type}
+                {date && formatDate(date)} /{' '}
+                {page.includes('research/cdr-verification/')
+                  ? 'Verification Framework Tool'
+                  : metadata.type}
               </Box>
               <Box sx={{ variant: 'styles.h3', mt: 4, mb: 3 }}>
                 <Link
@@ -143,9 +145,14 @@ const Search = ({ contents }) => {
                   {metadata.title}
                 </Link>
               </Box>
-              <Box sx={{ mb: 3 }}>{metadata.summary}</Box>
-              <Box sx={sx.label}>{metadata.authors?.join(' + ')}</Box>
-              <Divider sx={{ my: 4 }} />
+
+              <Box>{metadata.summary}</Box>
+
+              {metadata.authors?.length > 0 && (
+                <Box sx={{ ...sx.label, mt: 3 }}>
+                  {metadata.authors?.join(' + ')}
+                </Box>
+              )}
             </Box>
           ))}
         </Column>
@@ -157,16 +164,19 @@ const Search = ({ contents }) => {
 export default Search
 
 export const getStaticProps = async () => {
-  const [research, blog] = await Promise.all([
+  const [research, blog, vcl] = await Promise.all([
     fetch(
       'https://research-git-katamartin-metadata-carbonplan.vercel.app/research/contents.json'
     ).then((res) => res.json()),
     fetch(
       'https://blog-git-katamartin-metadata-carbonplan.vercel.app/blog/contents.json'
     ).then((res) => res.json()),
+    fetch(
+      'https://cdr-mrv-git-katamartin-metadata-carbonplan.vercel.app/research/cdr-verification/contents.json'
+    ).then((res) => res.json()),
   ])
 
-  const contents = [...research, ...blog]
+  const contents = [...research, ...blog, ...vcl]
     .filter((el) => el.metadata)
     .map((el) =>
       el.metadata.authors

--- a/pages/search.js
+++ b/pages/search.js
@@ -4,7 +4,6 @@ import {
   Row,
   Column,
   Link,
-  Heading,
   Filter,
   formatDate,
   Input,
@@ -70,11 +69,24 @@ const Search = ({ contents }) => {
         'Public list of all our sources of unrestricted or project-specific funding greater than $1000.'
       }
     >
-      <Heading
-        description={`There ${results.length} results that match your search.`}
-      >
-        Search
-      </Heading>
+      <Row sx={{ mt: [5, 6, 7, 8], mb: [5, 6, 7, 8], ...sx }}>
+        <Column start={[1, 1, 2, 2]} width={[6, 6, 3, 3]}>
+          <Box as='h1' variant='styles.h1' sx={{ my: [0, 0, 0, 0] }}>
+            Search
+          </Box>
+        </Column>
+        <Column start={[1, 1, 5, 5]} width={[6]}>
+          <Flex
+            sx={{
+              height: '100%',
+              alignItems: 'flex-end',
+              pb: '4px',
+            }}
+          >
+            There {results.length} results that match your search.
+          </Flex>
+        </Column>
+      </Row>
       <Row>
         <Column start={[1, 1, 2, 2]} width={[6, 6, 2, 2]}>
           <Flex sx={{ flexDirection: 'column', gap: 5 }}>

--- a/pages/search.js
+++ b/pages/search.js
@@ -217,7 +217,11 @@ const Search = ({ contents }) => {
                         ? page
                         : `https://carbonplan.org/${page}`
                     }
-                    sx={{ textDecoration: 'none' }}
+                    sx={{
+                      textDecoration: 'none',
+                      transition: 'color 0.2s',
+                      '&:hover': { color: metadata.color ?? 'secondary' },
+                    }}
                   >
                     {metadata.title}
                   </Link>

--- a/pages/search.js
+++ b/pages/search.js
@@ -1,0 +1,178 @@
+import { Box, Divider, Flex } from 'theme-ui'
+import {
+  Layout,
+  Row,
+  Column,
+  Link,
+  Heading,
+  Filter,
+  formatDate,
+  Input,
+} from '@carbonplan/components'
+import { useMemo, useState } from 'react'
+import { useRouter } from 'next/router'
+
+const sx = {
+  label: {
+    fontFamily: 'mono',
+    letterSpacing: 'mono',
+    fontSize: [1, 1, 1, 2],
+    color: 'secondary',
+    userSelect: 'none',
+    textTransform: 'uppercase',
+  },
+}
+
+const Search = ({ contents }) => {
+  const router = useRouter()
+  const [sort, setSort] = useState({
+    newest: true,
+    oldest: false,
+  })
+  const [filter, setFilter] = useState({
+    article: true,
+    tool: true,
+    blog: true,
+    commentary: true,
+    other: true,
+  })
+
+  const results = useMemo(() => {
+    return contents
+      .filter((c) => c.date)
+      .filter((c) =>
+        router.query.query
+          ? [
+              c.page,
+              c.metadata.title,
+              c.metadata.summary,
+              ...(c.metadata.authors ? c.metadata.authors : []),
+            ].some((text) =>
+              text?.toLowerCase().includes(router.query.query.toLowerCase())
+            )
+          : true
+      )
+      .filter((c) =>
+        filter.hasOwnProperty(c.metadata.type)
+          ? filter[c.metadata.type]
+          : filter.other
+      )
+      .sort(
+        (a, b) => (new Date(b.date) - new Date(a.date)) * (sort.oldest ? -1 : 1)
+      )
+  }, [contents, sort, filter, router.query.query])
+
+  return (
+    <Layout
+      links={'homepage'}
+      title={'Search – CarbonPlan'}
+      description={
+        'Public list of all our sources of unrestricted or project-specific funding greater than $1000.'
+      }
+    >
+      <Heading
+        description={`There ${results.length} results that match your search.`}
+      >
+        Search
+      </Heading>
+      <Row>
+        <Column start={[1, 1, 2, 2]} width={[6, 6, 2, 2]}>
+          <Flex sx={{ flexDirection: 'column', gap: 5 }}>
+            <Box>
+              <Box as='label' sx={sx.label}>
+                Query
+                <Input
+                  value={router.query.query ?? ''}
+                  onChange={(e) =>
+                    router.replace(
+                      {
+                        pathname: '/search',
+                        query: { query: e.target.value },
+                      },
+                      undefined,
+                      {
+                        scroll: false,
+                        shallow: true,
+                      }
+                    )
+                  }
+                  size='xs'
+                  sx={{
+                    mt: 3,
+                    width: '100%',
+                    fontFamily: 'mono',
+                    letterSpacing: 'mono',
+                    fontSize: [1, 1, 1, 2],
+                    textTransform: 'uppercase',
+                  }}
+                />
+              </Box>
+            </Box>
+            <Filter values={sort} setValues={setSort} label='Sort by' />
+            <Filter
+              values={filter}
+              setValues={setFilter}
+              label='Filter by type'
+              showAll
+            />
+          </Flex>
+        </Column>
+        <Column start={[1, 1, 5, 5]} width={[6, 5, 5, 5]}>
+          {results.map(({ page, date, metadata }) => (
+            <Box key={page}>
+              <Box sx={sx.label}>
+                {date && formatDate(date)} / {metadata.type}
+              </Box>
+              <Box sx={{ variant: 'styles.h3', mt: 4, mb: 3 }}>
+                <Link
+                  href={`https://carbonplan.org/${page}`}
+                  sx={{ textDecoration: 'none' }}
+                >
+                  {metadata.title}
+                </Link>
+              </Box>
+              <Box sx={{ mb: 3 }}>{metadata.summary}</Box>
+              <Box sx={sx.label}>{metadata.authors?.join(' + ')}</Box>
+              <Divider sx={{ my: 4 }} />
+            </Box>
+          ))}
+        </Column>
+      </Row>
+    </Layout>
+  )
+}
+
+export default Search
+
+export const getStaticProps = async () => {
+  const [research, blog] = await Promise.all([
+    fetch(
+      'https://research-git-katamartin-metadata-carbonplan.vercel.app/research/contents.json'
+    ).then((res) => res.json()),
+    fetch(
+      'https://blog-git-katamartin-metadata-carbonplan.vercel.app/blog/contents.json'
+    ).then((res) => res.json()),
+  ])
+
+  const contents = [...research, ...blog]
+    .filter((el) => el.metadata)
+    .map((el) =>
+      el.metadata.authors
+        ? {
+            ...el,
+            metadata: {
+              ...el.metadata,
+              authors: el.metadata.authors.map((a) =>
+                typeof a === 'string' ? a : a.name
+              ),
+            },
+          }
+        : el
+    )
+  return {
+    props: { contents },
+    // Next.js will invalidate the cache when a
+    // request comes in, at most once every hour.
+    revalidate: 60 * 60,
+  }
+}

--- a/pages/search.js
+++ b/pages/search.js
@@ -60,7 +60,7 @@ const Search = ({ contents }) => {
               c.metadata.summary,
               ...(c.metadata.authors ? c.metadata.authors : []),
             ].some((text) => text?.toLowerCase().includes(query.toLowerCase()))
-          : false
+          : true
       )
       .filter((c) =>
         filter.hasOwnProperty(c.metadata.type)
@@ -103,37 +103,44 @@ const Search = ({ contents }) => {
       }
     >
       <Row sx={{ mt: [5, 6, 7, 8], mb: [5, 6, 7, 8], ...sx }}>
-        <Column start={[1, 1, 2, 2]} width={[6, 6, 3, 3]}>
+        <Column start={[1, 2, 2, 2]} width={[6, 2, 3, 3]}>
           <Box as='h1' variant='styles.h1' sx={{ my: [0, 0, 0, 0] }}>
             Search
           </Box>
         </Column>
-        <Column start={[1, 1, 5, 5]} width={[6]}>
+        <Column start={[1, 4, 5, 5]} width={[4, 4, 6, 6]}>
           <Flex
             sx={{
+              display: ['none', 'flex', 'flex', 'flex'],
               height: '100%',
               alignItems: 'flex-end',
               pb: '4px',
             }}
           >
-            {query
-              ? `There are ${results.length} results that match your search.`
-              : 'Enter a search query below to view results.'}
+            There are {results.length} results that match your search.
           </Flex>
         </Column>
       </Row>
       <Row>
-        <Column start={[1, 1, 2, 2]} width={[6, 6, 2, 2]}>
+        <Column start={[1, 2, 2, 2]} width={[6, 2, 2, 2]}>
           <Flex sx={{ flexDirection: 'column', gap: 5 }}>
             <Box>
-              <Box as='label' sx={sx.label}>
-                Query
+              <Box as='label'>
+                <Box
+                  as='span'
+                  sx={{
+                    ...sx.label,
+                    display: ['none', 'inherit', 'inherit', 'inherit'],
+                  }}
+                >
+                  Query
+                </Box>
                 <Input
                   value={query ?? ''}
                   onChange={(e) => setQuery(e.target.value)}
                   size='xs'
                   sx={{
-                    mt: 3,
+                    mt: ['-12px', 3, 3, 3],
                     width: '100%',
                     fontFamily: 'mono',
                     letterSpacing: 'mono',
@@ -152,7 +159,13 @@ const Search = ({ contents }) => {
             />
           </Flex>
         </Column>
-        <Column start={[1, 1, 5, 5]} width={[6, 5, 5, 5]}>
+        <Column start={[1, 4, 5, 5]} width={[6, 4, 5, 5]}>
+          <Divider
+            sx={{ my: 4, display: ['inherit', 'none', 'none', 'none'] }}
+          />
+          {results.length === 0 && (
+            <Box sx={{ ...sx.label }}>No results found</Box>
+          )}
           {results.map(({ page, date, metadata }, i) => (
             <Box key={page}>
               {i > 0 && <Divider sx={{ my: 4 }} />}

--- a/pages/search.js
+++ b/pages/search.js
@@ -59,14 +59,13 @@ const Search = ({ contents }) => {
     other: true,
   })
 
-  const effectiveQuery =
-    query ??
-    (router.isReady && typeof router.query.query === 'string'
-      ? router.query.query
-      : null)
+  let effectiveQuery = query
+  if (!query && router.isReady) {
+    effectiveQuery = router.query.query ?? ''
+  }
 
   const results = useMemo(() => {
-    if (!router.isReady) return []
+    if (effectiveQuery === null) return []
     return contents
       .filter((c) => {
         if (!effectiveQuery) return true
@@ -89,7 +88,7 @@ const Search = ({ contents }) => {
       .sort(
         (a, b) => (new Date(b.date) - new Date(a.date)) * (sort.oldest ? -1 : 1)
       )
-  }, [contents, sort, filter, effectiveQuery, router.isReady])
+  }, [contents, sort, filter, effectiveQuery])
 
   useEffect(() => {
     if (typeof query === 'string') {
@@ -128,8 +127,8 @@ const Search = ({ contents }) => {
               pb: '4px',
             }}
           >
-            {router.isReady &&
-              (typeof effectiveQuery === 'string'
+            {typeof effectiveQuery === 'string' &&
+              (effectiveQuery
                 ? `There are ${results.length} results that match your search.`
                 : 'Enter a query to filter results.')}
           </Flex>

--- a/pages/search.js
+++ b/pages/search.js
@@ -201,13 +201,14 @@ const Search = ({ contents }) => {
             sx={{ my: 4, display: ['inherit', 'none', 'none', 'none'] }}
           />
           {results.length === 0 && (
-            <Box sx={{ ...sx.label }}>No results found</Box>
+            <Box as='span' sx={{ ...sx.label }}>
+              No results found
+            </Box>
           )}
-
           {results.map(({ page, date, metadata }, i) => (
             <Box key={page}>
               {i > 0 && <Divider sx={{ my: 4 }} />}
-              <Box sx={sx.label}>
+              <Box as='span' sx={sx.label}>
                 {date && `${formatDate(date)} / `}
                 {getType(page, metadata)}
               </Box>
@@ -227,9 +228,7 @@ const Search = ({ contents }) => {
                   {metadata.title}
                 </Link>
               </Box>
-
               <Box>{metadata.summary}</Box>
-
               {metadata.authors?.length > 0 && (
                 <Box sx={{ ...sx.label, mt: 3 }}>
                   {metadata.authors?.join(' + ')}

--- a/pages/search.js
+++ b/pages/search.js
@@ -202,6 +202,22 @@ const EXTRA_CONTENT = [
       summary: 'Notes on accessing datasets stored in Zarr format.',
     },
   },
+  {
+    page: 'https://carbonplan.org/research/mcdr-tools',
+    date: '2025-06-04',
+    metadata: {
+      title: 'Index of tools visualizing marine CDR efficiency and dynamics',
+      summary: 'Notes on accessing datasets stored in Zarr format.',
+    },
+  },
+  {
+    page: 'https://carbonplan.org/research/mcdr-tools-about',
+    date: '2025-06-04',
+    metadata: {
+      title: 'About the Marine CDR Tools',
+      summary: 'Information about mCDR Efficiency Tools.',
+    },
+  },
 ]
 
 export const getStaticProps = async () => {

--- a/pages/search.js
+++ b/pages/search.js
@@ -8,7 +8,7 @@ import {
   formatDate,
   Input,
 } from '@carbonplan/components'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useRouter } from 'next/router'
 
 const sx = {
@@ -36,6 +36,7 @@ const getType = (page, metadata) => {
 
 const Search = ({ contents }) => {
   const router = useRouter()
+  const [query, setQuery] = useState(router.query.query ?? null)
   const [sort, setSort] = useState({
     newest: true,
     oldest: false,
@@ -52,15 +53,13 @@ const Search = ({ contents }) => {
     return contents
       .filter((c) => c.date)
       .filter((c) =>
-        router.query.query
+        query
           ? [
               c.page,
               c.metadata.title,
               c.metadata.summary,
               ...(c.metadata.authors ? c.metadata.authors : []),
-            ].some((text) =>
-              text?.toLowerCase().includes(router.query.query.toLowerCase())
-            )
+            ].some((text) => text?.toLowerCase().includes(query.toLowerCase()))
           : false
       )
       .filter((c) =>
@@ -71,7 +70,29 @@ const Search = ({ contents }) => {
       .sort(
         (a, b) => (new Date(b.date) - new Date(a.date)) * (sort.oldest ? -1 : 1)
       )
-  }, [contents, sort, filter, router.query.query])
+  }, [contents, sort, filter, query])
+
+  useEffect(() => {
+    if (router.isReady && router.query.query && typeof query !== 'string') {
+      setQuery(router.query.query)
+    }
+  }, [router])
+
+  useEffect(() => {
+    if (typeof query === 'string') {
+      router.replace(
+        {
+          pathname: '/search',
+          query: { query },
+        },
+        undefined,
+        {
+          scroll: false,
+          shallow: true,
+        }
+      )
+    }
+  }, [query])
 
   return (
     <Layout
@@ -95,7 +116,7 @@ const Search = ({ contents }) => {
               pb: '4px',
             }}
           >
-            {router.query.query
+            {query
               ? `There are ${results.length} results that match your search.`
               : 'Enter a search query below to view results.'}
           </Flex>
@@ -108,20 +129,8 @@ const Search = ({ contents }) => {
               <Box as='label' sx={sx.label}>
                 Query
                 <Input
-                  value={router.query.query ?? ''}
-                  onChange={(e) =>
-                    router.replace(
-                      {
-                        pathname: '/search',
-                        query: { query: e.target.value },
-                      },
-                      undefined,
-                      {
-                        scroll: false,
-                        shallow: true,
-                      }
-                    )
-                  }
+                  value={query ?? ''}
+                  onChange={(e) => setQuery(e.target.value)}
                   size='xs'
                   sx={{
                     mt: 3,

--- a/pages/search.js
+++ b/pages/search.js
@@ -125,7 +125,8 @@ const Search = ({ contents }) => {
               pb: '4px',
             }}
           >
-            There are {results.length} results that match your search.
+            {typeof query === 'string' &&
+              `There are ${results.length} results that match your search.`}
           </Flex>
         </Column>
       </Row>
@@ -174,34 +175,35 @@ const Search = ({ contents }) => {
           {results.length === 0 && (
             <Box sx={{ ...sx.label }}>No results found</Box>
           )}
-          {results.map(({ page, date, metadata }, i) => (
-            <Box key={page}>
-              {i > 0 && <Divider sx={{ my: 4 }} />}
-              <Box sx={sx.label}>
-                {date && formatDate(date)} / {getType(page, metadata)}
-              </Box>
-              <Box sx={{ variant: 'styles.h3', mt: 4, mb: 3 }}>
-                <Link
-                  href={
-                    page.includes('https://')
-                      ? page
-                      : `https://carbonplan.org/${page}`
-                  }
-                  sx={{ textDecoration: 'none' }}
-                >
-                  {metadata.title}
-                </Link>
-              </Box>
-
-              <Box>{metadata.summary}</Box>
-
-              {metadata.authors?.length > 0 && (
-                <Box sx={{ ...sx.label, mt: 3 }}>
-                  {metadata.authors?.join(' + ')}
+          {typeof query === 'string' &&
+            results.map(({ page, date, metadata }, i) => (
+              <Box key={page}>
+                {i > 0 && <Divider sx={{ my: 4 }} />}
+                <Box sx={sx.label}>
+                  {date && formatDate(date)} / {getType(page, metadata)}
                 </Box>
-              )}
-            </Box>
-          ))}
+                <Box sx={{ variant: 'styles.h3', mt: 4, mb: 3 }}>
+                  <Link
+                    href={
+                      page.includes('https://')
+                        ? page
+                        : `https://carbonplan.org/${page}`
+                    }
+                    sx={{ textDecoration: 'none' }}
+                  >
+                    {metadata.title}
+                  </Link>
+                </Box>
+
+                <Box>{metadata.summary}</Box>
+
+                {metadata.authors?.length > 0 && (
+                  <Box sx={{ ...sx.label, mt: 3 }}>
+                    {metadata.authors?.join(' + ')}
+                  </Box>
+                )}
+              </Box>
+            ))}
         </Column>
       </Row>
     </Layout>

--- a/pages/search.js
+++ b/pages/search.js
@@ -266,8 +266,8 @@ const EXTRA_CONTENT = [
     page: 'https://carbonplan.org/research/mcdr-tools',
     date: '2025-06-04',
     metadata: {
-      title: 'Index of tools visualizing marine CDR efficiency and dynamics',
-      summary: 'Notes on accessing datasets stored in Zarr format.',
+      title: 'Mapping Marine CDR',
+      summary: 'Index of tools visualizing marine CDR efficiency and dynamics.',
     },
   },
   {

--- a/pages/sitemap.xml.js
+++ b/pages/sitemap.xml.js
@@ -27,6 +27,7 @@ function generateSiteMap(pages) {
         `
        }).join('')}
        ${pages
+         .filter(({ page }) => !page.startsWith('http'))
          .map(({ page, date }) => {
            return `
             <url>

--- a/pages/sitemap.xml.js
+++ b/pages/sitemap.xml.js
@@ -1,4 +1,4 @@
-const { PAGES } = require('../data/pages')
+import { PAGES } from '../data/pages'
 
 const BASE_URL = 'https://carbonplan.org'
 

--- a/pages/sitemap.xml.js
+++ b/pages/sitemap.xml.js
@@ -1,17 +1,6 @@
-const BASE_URL = 'https://carbonplan.org'
+const { PAGES } = require('../data/pages')
 
-const ROUTES = [
-  'about',
-  'disclosures',
-  'donate',
-  'faq',
-  'funding',
-  'press',
-  'team',
-  'terms',
-  'thanks',
-  'design',
-]
+const BASE_URL = 'https://carbonplan.org'
 
 function generateSiteMap(pages) {
   return `<?xml version="1.0" encoding="UTF-8"?>
@@ -19,13 +8,15 @@ function generateSiteMap(pages) {
        <url>
          <loc>${BASE_URL}</loc>
        </url>
-       ${ROUTES.map((route) => {
-         return `
+       ${Object.keys(PAGES)
+         .map((route) => {
+           return `
           <url>
             <loc>${`${BASE_URL}/${route}`}</loc>
           </url>
         `
-       }).join('')}
+         })
+         .join('')}
        ${pages
          .filter(({ page }) => !page.startsWith('http'))
          .map(({ page, date }) => {

--- a/pages/team.js
+++ b/pages/team.js
@@ -2,6 +2,7 @@ import { Box, Image, Divider, Link, Grid } from 'theme-ui'
 import { Layout, Row, Column, Heading, Avatar } from '@carbonplan/components'
 import AnnotatedTable from '../components/annotated-table'
 import { team, board } from '../data/team'
+import { PAGES } from '../data/pages'
 
 const colors = ['red', 'orange', 'yellow', 'pink']
 
@@ -9,9 +10,9 @@ const Team = () => {
   return (
     <Layout
       links={'homepage'}
-      title={'Team – CarbonPlan'}
+      title={PAGES.team.title}
       nav={'team'}
-      description={'Meet our core team and our Board of Directors.'}
+      description={PAGES.team.description}
     >
       <Heading
         sidenote={

--- a/pages/terms.js
+++ b/pages/terms.js
@@ -1,14 +1,13 @@
 import { Box } from 'theme-ui'
 import { Layout, Row, Column, Link, Heading } from '@carbonplan/components'
+import { PAGES } from '../data/pages'
 
 const Terms = () => {
   return (
     <Layout
       links={'homepage'}
-      title={'Terms – CarbonPlan'}
-      description={
-        'Terms of use related to our website, code, data, and content.'
-      }
+      title={PAGES.terms.title}
+      description={PAGES.terms.description}
     >
       <Heading>Terms of use</Heading>
       <Row>

--- a/public/resources.json
+++ b/public/resources.json
@@ -1,0 +1,65 @@
+[
+  {
+    "label": "Carbon accounting",
+    "links": [
+      {
+        "label": "OffsetsDB",
+        "href": "https://carbonplan.org/research/offsets-db"
+      },
+      {
+        "label": "VCL tool",
+        "href": "https://carbonplan.org/research/cdr-verification"
+      },
+      {
+        "label": "Fires and forest offsets",
+        "href": "https://carbonplan.org/research/forest-offsets-fires"
+      },
+      {
+        "label": "mCDR tools",
+        "href": "https://carbonplan.org/research/mcdr-tools"
+      }
+    ]
+  },
+  {
+    "label": "Climate impacts",
+    "links": [
+      {
+        "label": "Open Climate Risk",
+        "href": "https://carbonplan.org/research/climate-risk"
+      },
+      {
+        "label": "Extreme heat",
+        "href": "https://carbonplan.org/research/extreme-heat-explainer"
+      },
+      {
+        "label": "Risk (dis)agreement",
+        "href": "https://carbonplan.org/research/climate-risk-comparison"
+      },
+      {
+        "label": "CMIP6 downscaling",
+        "href": "https://carbonplan.org/research/cmip6-downscaling"
+      }
+    ]
+  },
+  {
+    "label": "Organization",
+    "links": [
+      {
+        "label": "Team",
+        "href": "https://carbonplan.org/team"
+      },
+      {
+        "label": "Funding",
+        "href": "https://carbonplan.org/funding"
+      },
+      {
+        "label": "Press",
+        "href": "https://carbonplan.org/press"
+      },
+      {
+        "label": "Annual report",
+        "href": "https://files.carbonplan.org/CarbonPlan-Annual-Report-2025.pdf"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
See also:
- https://github.com/carbonplan/components/pull/194
- And metadata configuration in [research](https://github.com/carbonplan/research/compare/katamartin/metadata?expand=1), [blog](https://github.com/carbonplan/blog/compare/katamartin/metadata?expand=1), and [cdr-verification](https://github.com/carbonplan/cdr-verification/compare/katamartin/metadata?expand=1)